### PR TITLE
Add missing pandas dependency.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ description = "Unix embedding driver for software 2.0"
 dependencies = [
     "pytest",
     "sentence_transformers",
+    "pandas",
     "is_instance >= 0.0.5",
     "assure >= 0.0.5",
     "mmry >= 0.0.5",


### PR DESCRIPTION
When using `embd.List()`, `import pandas` fails due to missing dependency. 

Pandas was not listed as a direct dependency and doesn't get pulled in from other dependent packages either.

Example:

<img width="957" height="503" alt="embd-missing-pandas" src="https://github.com/user-attachments/assets/d46c4b03-1473-4202-8b3e-f42b95b9248f" />

