### PR TITLE
Fix pandas FutureWarning incompatible datatype

### DIFF
--- a/src/embd/types.py
+++ b/src/embd/types.py
@@ -173,6 +173,7 @@ class F(O):
         import numpy as np
         s = self @ promote(other)
         i = np.argsort(-s)
+        s = s.astype(object)
         s.iloc[:, :] = s.columns.values[i]
         s.columns = list(range(1, len(s.columns)+1))
         return s


### PR DESCRIPTION
Using embd top() gives this error:

```
>>> import embd
>>> embds = embd.List(["yellow car", "blue sky"])
>>> colours = embd.List(["yellow", "green", "blue"])
>>> top = embds.top(colours)
/home/ramya/env/echomap/lib/python3.11/site-packages/embd/types.py:176: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise in a future error of pandas. Value '['yellow', 'blue']' has dtype incompatible with float32, please explicitly cast to a compatible dtype first.
  s.iloc[:, :] = s.columns.values[i]
/home/ramya/env/echomap/lib/python3.11/site-packages/embd/types.py:176: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise in a future error of pandas. Value '['blue', 'green']' has dtype incompatible with float32, please explicitly cast to a compatible dtype first.
  s.iloc[:, :] = s.columns.values[i]
/home/ramya/env/echomap/lib/python3.11/site-packages/embd/types.py:176: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise in a future error of pandas. Value '['green', 'yellow']' has dtype incompatible with float32, please explicitly cast to a compatible dtype first.
  s.iloc[:, :] = s.columns.values[i]
>>> top
['yellow', 'blue']
```

In `types.py`, line 176:
```
    def get(self, other):
        import numpy as np
        s = self @ promote(other)
        i = np.argsort(-s)
        s.iloc[:, :] = s.columns.values[i]                           <----------- HERE
        s.columns = list(range(1, len(s.columns)+1))
        return s

    def top(self, other, n=1):
        s = self.get(other)
        return s[1].tolist()

```
1. `s` contains similarity scores (float32 values) between embeddings
2. `s.columns.values[i]` contains the reordered string labels from other (like `['yellow', 'blue']`)
3. Tries to overwrite the float32 similarity scores with string labels, which pandas complains as incompatible dtypes

Not a big deal, but looks ugly when using in scripts or anywhere else, without a bunch of ignore warnings stuff and this is a cool library so I wanna keep using it and have it look nice. 

Woot woot! 🎉